### PR TITLE
Add dynamic language filtering by active language

### DIFF
--- a/plugins/system/filtermagic/src/Field/SubcategoryField.php
+++ b/plugins/system/filtermagic/src/Field/SubcategoryField.php
@@ -51,8 +51,9 @@ class SubcategoryField extends ListField
 			$filters['filter.published'] = explode(',', $published);
 		}
 
-		if ($language)
-		{
+		if ($language === 'auto') {
+			$filters['filter.language'] = Factory::getApplication()->getLanguage()->getTag();
+		} elseif ($language) {
 			$filters['filter.language'] = explode(',', $language);
 		}
 


### PR DESCRIPTION
Allows the 'auto' value in the language attribute for the Subcategory field.

When auto is used, the field checks for the current language and filters based on that.